### PR TITLE
[Modular] Removes whitelist from donor items

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -1,5 +1,5 @@
 //This is the file that handles donator loadout items.
-
+/* moved to modular_skyrat
 /datum/gear/pingcoderfailsafe
 	name = "IF YOU SEE THIS, PING A CODER RIGHT NOW!"
 	category = SLOT_IN_BACKPACK
@@ -101,7 +101,7 @@
 	category = SLOT_NECK
 	path = /obj/item/clothing/neck/cloak/festive
 	ckeywhitelist = list("illotafv")
-
+*/
 /datum/gear/carrotplush
 	name = "Carrot plushie"
 	category = SLOT_IN_BACKPACK
@@ -113,7 +113,7 @@
 	category = SLOT_NECK
 	path = /obj/item/clothing/neck/cloak/carrot
 	ckeywhitelist = list("improvedname")
-
+/* moved to modular_skyrat
 /datum/gear/albortorosamask
 	name = "Alborto Rosa mask"
 	category = SLOT_WEAR_MASK
@@ -131,13 +131,13 @@
 	category = SLOT_SHOES
 	path = /obj/item/clothing/shoes/sneakers/pink
 	ckeywhitelist = list("zigfie")
-
+*/
 /datum/gear/reecesgreatcoat
 	name = "Reece's Great Coat"
 	category = SLOT_WEAR_SUIT
 	path = /obj/item/clothing/suit/trenchcoat/green
 	ckeywhitelist = list("geemiesif")
-
+/* moved to modular_skyrat
 /datum/gear/russianflask
 	name = "Russian flask"
 	category = SLOT_IN_BACKPACK
@@ -150,13 +150,13 @@
 	category = SLOT_WEAR_MASK
 	path = /obj/item/clothing/mask/gas/stalker
 	ckeywhitelist = list("slomka")
-
+*/
 /datum/gear/stripedcollar
 	name = "Striped collar"
 	category = SLOT_NECK
 	path = /obj/item/clothing/neck/petcollar/stripe
 	ckeywhitelist = list("jademanique")
-
+/* moved to modular_skyrat
 /datum/gear/performersoutfit
 	name = "Bluish performer's outfit"
 	category = SLOT_W_UNIFORM
@@ -174,13 +174,13 @@
 	category = SLOT_IN_BACKPACK
 	path = /obj/item/gun/ballistic/automatic/AM4B
 	ckeywhitelist = list("zeronetalpha")
-
+*/
 /datum/gear/carrotsatchel
 	name = "Carrot Satchel"
 	category = SLOT_HANDS
 	path = /obj/item/storage/backpack/satchel/carrot
 	ckeywhitelist = list("improvedname")
-
+/* moved to modular_skyrat
 /datum/gear/naomisweater
 	name = "worn black sweater"
 	category = SLOT_W_UNIFORM
@@ -488,3 +488,4 @@ datum/gear/darksabresheath
 	category = SLOT_SHOES
 	path = /obj/item/clothing/shoes/sneakers/mikuleggings
 	ckeywhitelist = list("grandvegeta")
+*/

--- a/modular_skyrat/code/modules/client/loadout/__donator.dm
+++ b/modular_skyrat/code/modules/client/loadout/__donator.dm
@@ -1,0 +1,386 @@
+//This is the file that handles donator loadout items.
+
+/datum/gear/pingcoderfailsafe
+	name = "IF YOU SEE THIS, PING A CODER RIGHT NOW!"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/bikehorn/golden
+	ckeywhitelist = list("This entry should never appear with this variable set.") //If it does, then that means somebody fucked up the whitelist system pretty hard
+
+/datum/gear/donortestingbikehorn
+	name = "Donor item testing bikehorn"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/bikehorn
+	geargroupID = list("DONORTEST") //This is a list mainly for the sake of testing, but geargroupID works just fine with ordinary strings
+
+/datum/gear/kevhorn
+	name = "Airhorn"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/bikehorn/airhorn
+
+/datum/gear/cebusoap
+	name = "Cebutris' soap"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/custom/ceb_soap
+
+/datum/gear/kiaracloak
+	name = "Kiara's cloak"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/cloak/inferno
+
+/datum/gear/kiaracollar
+	name = "Kiara's collar"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/petcollar/inferno
+
+/datum/gear/kiaramedal
+	name = "Insignia of Steele"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/clothing/accessory/medal/steele
+
+/datum/gear/hheart
+	name = "The Hollow Heart"
+	category = SLOT_WEAR_MASK
+	path = /obj/item/clothing/mask/hheart
+
+/datum/gear/engravedzippo
+	name = "Engraved zippo"
+	category = SLOT_HANDS
+	path = /obj/item/lighter/gold
+
+/datum/gear/geisha
+	name = "Geisha suit"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/geisha
+
+/datum/gear/specialscarf
+	name = "Special scarf"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/scarf/zomb
+
+/datum/gear/redmadcoat
+	name = "The Mad's labcoat"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/toggle/labcoat/mad/red
+
+/datum/gear/santahat
+	name = "Santa hat"
+	category = SLOT_HEAD
+	path = /obj/item/clothing/head/santa/fluff
+
+/datum/gear/reindeerhat
+	name = "Reindeer hat"
+	category = SLOT_HEAD
+	path = /obj/item/clothing/head/hardhat/reindeer/fluff
+	
+/datum/gear/treeplushie
+	name = "Christmas tree plushie"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/toy/plush/tree
+
+/datum/gear/santaoutfit
+	name = "Santa costume"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/space/santa/fluff
+
+/datum/gear/treecloak
+	name = "Christmas tree cloak"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/cloak/festive
+
+/datum/gear/albortorosamask
+	name = "Alborto Rosa mask"
+	category = SLOT_WEAR_MASK
+	path = /obj/item/clothing/mask/luchador/zigfie
+
+/datum/gear/mankini
+	name = "Mankini"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/mankini
+
+/datum/gear/pinkshoes
+	name = "Pink shoes"
+	category = SLOT_SHOES
+	path = /obj/item/clothing/shoes/sneakers/pink
+
+/datum/gear/russianflask
+	name = "Russian flask"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/reagent_containers/food/drinks/flask/russian
+	cost = 2
+
+/datum/gear/stalkermask
+	name = "S.T.A.L.K.E.R. mask"
+	category = SLOT_WEAR_MASK
+	path = /obj/item/clothing/mask/gas/stalker
+
+/datum/gear/performersoutfit
+	name = "Bluish performer's outfit"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/singery/custom
+
+/datum/gear/vermillion
+	name = "Vermillion clothing"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/suit/vermillion
+
+/datum/gear/AM4B
+	name = "Foam Force AM4-B"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/gun/ballistic/automatic/AM4B
+
+/datum/gear/naomisweater
+	name = "worn black sweater"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/bb_sweater/black/naomi
+
+/datum/gear/naomicollar
+	name = "worn pet collar"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/petcollar/naomi
+
+/datum/gear/gladiator
+	name = "Gladiator Armor"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/under/gladiator
+
+/datum/gear/bloodredtie
+	name = "Blood Red Tie"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/tie/bloodred
+
+/datum/gear/puffydress
+	name = "Puffy Dress"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/puffydress
+
+/datum/gear/labredblack
+	name = "Black and Red Coat"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/toggle/labcoat/labredblack
+
+/datum/gear/torisword
+	name = "Rainbow Zweihander"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/twohanded/dualsaber/hypereutactic/toy/rainbow
+
+/datum/gear/darksabre
+	name = "Dark Sabre"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/toy/darksabre
+
+datum/gear/darksabresheath
+	name = "Dark Sabre Sheath"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/storage/belt/sabre/darksabre
+
+/datum/gear/toriball
+	name = "Rainbow Tennis Ball"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/toy/tennis/rainbow
+
+/datum/gear/izzyball
+	name = "Katlin's Ball"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/toy/tennis/rainbow/izzy
+
+/datum/gear/cloak
+	name = "Green Cloak"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/cloak/green
+
+/datum/gear/steelflask
+	name = "Steel Flask"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/reagent_containers/food/drinks/flask/steel
+	cost = 2
+
+/datum/gear/paperhat
+	name = "Paper Hat"
+	category = SLOT_HEAD
+	path = /obj/item/clothing/head/paperhat
+
+/datum/gear/cloakce
+	name = "Polychromic CE Cloak"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/clothing/neck/cloak/polychromic/polyce
+
+/datum/gear/ssk
+	name = "Stun Sword Kit"
+	category = SLOT_IN_BACKPACK
+	path = 	/obj/item/ssword_kit
+
+/datum/gear/techcoat
+	name = "Techomancers Labcoat"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/clothing/suit/toggle/labcoat/mad/techcoat
+
+/datum/gear/leechjar
+	name = "Jar of Leeches"
+	category = SLOT_IN_BACKPACK
+	path = 	/obj/item/custom/leechjar
+
+/datum/gear/darkarmor
+	name = "Dark Armor"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/clothing/suit/armor/vest/darkcarapace
+
+/datum/gear/devilwings
+	name = "Strange Wings"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/devilwings
+
+/datum/gear/flagcape
+	name = "US Flag Cape"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/clothing/neck/flagcape
+
+/datum/gear/luckyjack
+	name = "Lucky Jackboots"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/clothing/shoes/lucky
+
+/datum/gear/raiqbawks
+	name = "Miami Boombox"
+	category = SLOT_HANDS
+	cost = 2
+	path = /obj/item/boombox/raiq
+
+/datum/gear/m41
+	name = "Toy M41"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/toy/gun/m41
+
+/datum/gear/Divine_robes
+	name = "Divine robes"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/lunasune
+
+/datum/gear/gothcoat
+	name = "Goth Coat"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/gothcoat
+
+/datum/gear/corgisuit
+	name = "Corgi Suit"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/hooded/ian_costume
+
+/datum/gear/sharkcloth
+	name = "Leon's Skimpy Outfit"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/under/leoskimpy
+
+/datum/gear/mimemask
+	name = "Mime Mask"
+	category = SLOT_WEAR_MASK
+	path = /obj/item/clothing/mask/gas/mime
+
+/datum/gear/mimeoveralls
+	name = "Mime's Overalls"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/under/mimeoveralls
+
+/datum/gear/soulneck
+	name = "Soul Necklace"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/undertale
+
+/datum/gear/frenchberet
+	name = "French Beret"
+	category = SLOT_HEAD
+	path = /obj/item/clothing/head/frenchberet
+
+/datum/gear/zuliecloak
+	name = "Project: Zul-E"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/hooded/cloak/zuliecloak
+
+/datum/gear/blackredgold
+	name = "Black, Red, and Gold Coat"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/blackredgold
+
+/datum/gear/fritzplush
+	name = "Fritz Plushie"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/toy/plush/mammal/dog/fritz
+
+/datum/gear/kimono
+	name = "Kimono"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/kimono
+
+/datum/gear/commjacket
+	name = "Dusty Commisar's Cloak"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/commjacket
+
+/datum/gear/mw2_russian_para
+	name = "Russian Paratrooper Jumper"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/mw2_russian_para
+
+/datum/gear/longblackgloves
+	name = "Luna's Gauntlets"
+	category = SLOT_GLOVES
+	path = /obj/item/clothing/gloves/longblackgloves
+
+/datum/gear/trendy_fit
+	name = "Trendy Fit"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/trendy_fit
+
+/datum/gear/singery
+	name = "Yellow Performer Outfit"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/singery
+	
+/datum/gear/csheet
+	name = "NT Bedsheet"
+	category = SLOT_NECK
+	path = /obj/item/bedsheet/captain
+
+/datum/gear/borgplush
+	name = "Robot Plush"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/toy/plush/borgplushie
+
+/datum/gear/donorberet
+	name = "Atmos Beret"
+	category = SLOT_HEAD
+	path = /obj/item/clothing/head/blueberet
+
+/datum/gear/donorgoggles
+	name = "Flight Goggles"
+	category = SLOT_HEAD
+	path = /obj/item/clothing/head/flight
+	
+/datum/gear/onionneck
+	name = "Onion Necklace"
+	category = SLOT_NECK
+	path = /obj/item/clothing/neck/necklace/onion
+	
+/datum/gear/mikubikini
+	name = "starlight singer bikini"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/mikubikini
+
+/datum/gear/mikujacket
+	name = "starlight singer jacket"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/mikujacket
+
+/datum/gear/mikuhair
+	name = "starlight singer hair"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/head/mikuhair
+
+/datum/gear/mikugloves
+	name = "starlight singer gloves"
+	category = SLOT_GLOVES
+	path = /obj/item/clothing/gloves/mikugloves
+
+/datum/gear/mikuleggings
+	name = "starlight singer leggings"
+	category = SLOT_SHOES
+	path = /obj/item/clothing/shoes/sneakers/mikuleggings


### PR DESCRIPTION
## About The Pull Request

There is another PR for this that is not modular. This fixes that. Unwhitelists donor items.

## Why It's Good For The Game

Add variety to loadout, and allow for more customization for characters, thus promoting better RP. 

## Changelog
:cl:
del: Whitelist from donor items
/:cl: